### PR TITLE
Add missing math functions

### DIFF
--- a/src/main/java/com/eliotlash/molang/CompileConstants.java
+++ b/src/main/java/com/eliotlash/molang/CompileConstants.java
@@ -14,6 +14,8 @@ public class CompileConstants {
 
 	public CompileConstants() {
 		this.registerConstant("PI", Math.PI);
+		// Bedrock Parity
+		this.registerConstant("math.pi", Math.PI);
 		this.registerConstant("E", Math.E);
 	}
 

--- a/src/main/java/com/eliotlash/molang/functions/classic/Acos.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Acos.java
@@ -21,7 +21,7 @@ public class Acos extends Function {
 	@Override
 	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
 		double a = this.evaluateArgument(arguments, ctx, 0);
-		if (a > 1) {
+		if (Math.abs(a) > 1) {
 			return 0;
 		}
 		return Math.acos(a);

--- a/src/main/java/com/eliotlash/molang/functions/classic/Acos.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Acos.java
@@ -1,0 +1,29 @@
+package com.eliotlash.molang.functions.classic;
+
+import com.eliotlash.molang.ast.Expr;
+import com.eliotlash.molang.functions.Function;
+import com.eliotlash.molang.variables.ExecutionContext;
+
+/**
+ * Arc cosine function
+ */
+public class Acos extends Function {
+
+	public Acos(String name) {
+		super(name);
+	}
+
+	@Override
+	public int getRequiredArguments() {
+		return 1;
+	}
+
+	@Override
+	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
+		double a = this.evaluateArgument(arguments, ctx, 0);
+		if (a > 1) {
+			return 0;
+		}
+		return Math.acos(a);
+	}
+}

--- a/src/main/java/com/eliotlash/molang/functions/classic/Asin.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Asin.java
@@ -1,0 +1,29 @@
+package com.eliotlash.molang.functions.classic;
+
+import com.eliotlash.molang.ast.Expr;
+import com.eliotlash.molang.functions.Function;
+import com.eliotlash.molang.variables.ExecutionContext;
+
+/**
+ * Arc sine function
+ */
+public class Asin extends Function {
+
+	public Asin(String name) {
+		super(name);
+	}
+
+	@Override
+	public int getRequiredArguments() {
+		return 1;
+	}
+
+	@Override
+	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
+		double a = this.evaluateArgument(arguments, ctx, 0);
+		if (a > 1) {
+			return 0;
+		}
+		return Math.asin(a);
+	}
+}

--- a/src/main/java/com/eliotlash/molang/functions/classic/Asin.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Asin.java
@@ -21,7 +21,7 @@ public class Asin extends Function {
 	@Override
 	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
 		double a = this.evaluateArgument(arguments, ctx, 0);
-		if (a > 1) {
+		if (Math.abs(a) > 1) {
 			return 0;
 		}
 		return Math.asin(a);

--- a/src/main/java/com/eliotlash/molang/functions/classic/Atan.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Atan.java
@@ -1,0 +1,28 @@
+package com.eliotlash.molang.functions.classic;
+
+import com.eliotlash.molang.ast.Expr;
+import com.eliotlash.molang.functions.Function;
+import com.eliotlash.molang.variables.ExecutionContext;
+
+/**
+ * Arc tangent function
+ */
+public class Atan extends Function {
+
+	public Atan(String name) {
+		super(name);
+	}
+
+	@Override
+	public int getRequiredArguments() {
+		return 1;
+	}
+
+	@Override
+	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
+		double a = this.evaluateArgument(arguments, ctx, 0);
+		if (a > 1) {
+			return 0;
+		}
+		return Math.atan(a);	}
+}

--- a/src/main/java/com/eliotlash/molang/functions/classic/Atan.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Atan.java
@@ -21,7 +21,7 @@ public class Atan extends Function {
 	@Override
 	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
 		double a = this.evaluateArgument(arguments, ctx, 0);
-		if (a > 1) {
+		if (Math.abs(a) > 1) {
 			return 0;
 		}
 		return Math.atan(a);	}

--- a/src/main/java/com/eliotlash/molang/functions/classic/Atan2.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Atan2.java
@@ -1,0 +1,25 @@
+package com.eliotlash.molang.functions.classic;
+
+import com.eliotlash.molang.ast.Expr;
+import com.eliotlash.molang.functions.Function;
+import com.eliotlash.molang.variables.ExecutionContext;
+
+/**
+ * Arc tangent function
+ */
+public class Atan2 extends Function {
+
+	public Atan2(String name) {
+		super(name);
+	}
+
+	@Override
+	public int getRequiredArguments() {
+		return 2;
+	}
+
+	@Override
+	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
+		return Math.atan2(this.evaluateArgument(arguments, ctx, 0), this.evaluateArgument(arguments, ctx, 1));
+	}
+}

--- a/src/main/java/com/eliotlash/molang/functions/utility/DiceRoll.java
+++ b/src/main/java/com/eliotlash/molang/functions/utility/DiceRoll.java
@@ -1,0 +1,33 @@
+package com.eliotlash.molang.functions.utility;
+
+import com.eliotlash.molang.ast.Expr;
+import com.eliotlash.molang.functions.Function;
+import com.eliotlash.molang.variables.ExecutionContext;
+
+public class DiceRoll extends Function {
+	public java.util.Random random;
+
+
+	public DiceRoll(String name){
+		super(name);
+		this.random = new java.util.Random();
+	}
+
+	@Override
+	public int getRequiredArguments() {
+		return 3;
+	}
+
+	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
+		double returnValue = 0;
+		double rollCount = this.evaluateArgument(arguments, ctx, 0);
+		double min = this.evaluateArgument(arguments, ctx, 1);
+		double max = this.evaluateArgument(arguments, ctx, 2);
+
+		for (int i = 0; i < rollCount; i++) {
+			returnValue += this.random.nextDouble() * (max - min) + min;
+		}
+
+		return returnValue;
+	}
+}

--- a/src/main/java/com/eliotlash/molang/functions/utility/DiceRollInteger.java
+++ b/src/main/java/com/eliotlash/molang/functions/utility/DiceRollInteger.java
@@ -1,0 +1,33 @@
+package com.eliotlash.molang.functions.utility;
+
+import com.eliotlash.molang.ast.Expr;
+import com.eliotlash.molang.functions.Function;
+import com.eliotlash.molang.variables.ExecutionContext;
+
+public class DiceRollInteger extends Function {
+	public java.util.Random random;
+
+
+	public DiceRollInteger(String name){
+		super(name);
+		this.random = new java.util.Random();
+	}
+
+	@Override
+	public int getRequiredArguments() {
+		return 3;
+	}
+
+	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
+		double returnValue = 0;
+		double rollCount = this.evaluateArgument(arguments, ctx, 0);
+		double min = this.evaluateArgument(arguments, ctx, 1);
+		double max = this.evaluateArgument(arguments, ctx, 2);
+
+		for (int i = 0; i < rollCount; i++) {
+			returnValue += Math.round(this.random.nextDouble() * (max - min) + min);
+		}
+
+		return returnValue;
+	}
+}

--- a/src/main/java/com/eliotlash/molang/functions/utility/MinAngle.java
+++ b/src/main/java/com/eliotlash/molang/functions/utility/MinAngle.java
@@ -1,0 +1,28 @@
+package com.eliotlash.molang.functions.utility;
+
+import com.eliotlash.molang.ast.Expr;
+import com.eliotlash.molang.functions.Function;
+import com.eliotlash.molang.utils.Interpolations;
+import com.eliotlash.molang.variables.ExecutionContext;
+
+public class MinAngle extends Function {
+
+	public MinAngle(String name) {
+		super(name);
+	}
+
+	@Override
+	public int getRequiredArguments() {
+		return 3;
+	}
+
+	@Override
+	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
+		double result = this.evaluateArgument(arguments, ctx, 0);
+		// Clamp the result to -360 to 360, then add 360 to make it positive, then mod 360 to get the positive angle
+		result = ((result % 360) + 360) % 360;
+		// If the result is greater than 180, subtract 360 to get the negative angle
+		if (result > 179) result -= 360;
+		return result;
+	}
+}

--- a/src/main/java/com/eliotlash/molang/functions/utility/RandomInteger.java
+++ b/src/main/java/com/eliotlash/molang/functions/utility/RandomInteger.java
@@ -1,0 +1,40 @@
+package com.eliotlash.molang.functions.utility;
+
+import com.eliotlash.molang.ast.Expr;
+import com.eliotlash.molang.functions.Function;
+import com.eliotlash.molang.variables.ExecutionContext;
+
+public class RandomInteger extends Function {
+	public java.util.Random random;
+
+
+	public RandomInteger(String name){
+		super(name);
+		this.random = new java.util.Random();
+	}
+
+	public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
+		double random = 0;
+
+		if (arguments.length >= 3) {
+			this.random.setSeed((long) this.evaluateArgument(arguments, ctx, 2));
+			random = this.random.nextInt();
+		} else {
+			random = Math.round(Math.random());
+		}
+
+		if (arguments.length >= 2) {
+			double a = this.evaluateArgument(arguments, ctx, 0);
+			double b = this.evaluateArgument(arguments, ctx, 1);
+
+			double min = Math.min(a, b);
+			double max = Math.max(a, b);
+
+			random = random * (max - min) + min;
+		} else if (arguments.length >= 1) {
+			random = random * this.evaluateArgument(arguments, ctx, 0);
+		}
+
+		return random;
+	}
+}

--- a/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
+++ b/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
@@ -44,6 +44,10 @@ public class ExecutionContext {
         registerFunction("math", new Cos("cosradians"));
         registerFunction("math", new SinDegrees("sin"));
         registerFunction("math", new Sin("sinradians"));
+        registerFunction("math", new Asin("asin"));
+        registerFunction("math", new Acos("acos"));
+        registerFunction("math", new Atan("atan"));
+        registerFunction("math", new Atan2("atan2"));
         registerFunction("math", new Exp("exp"));
         registerFunction("math", new Ln("ln"));
         registerFunction("math", new Mod("mod"));

--- a/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
+++ b/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
@@ -13,8 +13,7 @@ import com.eliotlash.molang.functions.rounding.Ceil;
 import com.eliotlash.molang.functions.rounding.Floor;
 import com.eliotlash.molang.functions.rounding.Round;
 import com.eliotlash.molang.functions.rounding.Trunc;
-import com.eliotlash.molang.functions.utility.Lerp;
-import com.eliotlash.molang.functions.utility.LerpRotate;
+import com.eliotlash.molang.functions.utility.*;
 import com.eliotlash.molang.functions.utility.Random;
 import com.eliotlash.molang.utils.MolangUtils;
 import it.unimi.dsi.fastutil.Pair;
@@ -63,6 +62,8 @@ public class ExecutionContext {
         registerFunction("math", new Lerp("lerp"));
         registerFunction("math", new LerpRotate("lerprotate"));
         registerFunction("math", new Random("random"));
+        registerFunction("math", new DiceRoll("dice_roll"));
+        registerFunction("math", new DiceRollInteger("dice_roll_integer"));
     }
 
     public Evaluator getEvaluator() {

--- a/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
+++ b/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
@@ -61,6 +61,7 @@ public class ExecutionContext {
         registerFunction("math", new Trunc("trunc"));
         registerFunction("math", new Lerp("lerp"));
         registerFunction("math", new LerpRotate("lerprotate"));
+        registerFunction("math", new MinAngle("min_angle"));
         registerFunction("math", new Random("random"));
         registerFunction("math", new RandomInteger("random_integer"));
         registerFunction("math", new DiceRoll("dice_roll"));

--- a/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
+++ b/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
@@ -62,6 +62,7 @@ public class ExecutionContext {
         registerFunction("math", new Lerp("lerp"));
         registerFunction("math", new LerpRotate("lerprotate"));
         registerFunction("math", new Random("random"));
+        registerFunction("math", new RandomInteger("random_integer"));
         registerFunction("math", new DiceRoll("dice_roll"));
         registerFunction("math", new DiceRollInteger("dice_roll_integer"));
     }


### PR DESCRIPTION
https://bedrock.dev/docs/stable/Molang#Math%20Functions

The arc functions return 0 when their input's absolute value is greater than 1, due to the result of Java's math library being `NaN` otherwise.
If we want it to act exactly like Molang we'll need to implement our own arc functions that act exactly like the JavaScript ones.