### PR TITLE
Fix Operator Precedence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 
 apply plugin: 'maven-publish'
 apply plugin: 'com.google.cloud.artifactregistry.gradle-plugin'
-version = "1.0.9"
+version = "1.0.10"
 group = "com.eliotlash.molang"
 archivesBaseName = "particleman"
 

--- a/src/test/java/com/eliotlash/molang/ParserTest.java
+++ b/src/test/java/com/eliotlash/molang/ParserTest.java
@@ -124,8 +124,8 @@ public class ParserTest extends TestBase {
 		assertEquals(op(op(one, Operator.GT, one), Operator.EQ, one), e("1 > 1 == 1"));
 
 		// comparison/coalesce
-		assertEquals(op(one, Operator.LT, new Expr.Coalesce(a, one)), e("1 < a ?? 1"));
-		assertEquals(op(new Expr.Coalesce(a, one), Operator.LT, one), e("a ?? 1 < 1"));
+		assertEquals(new Expr.Coalesce(op(one, Operator.LT, a), one), e("1 < a ?? 1"));
+		assertEquals(new Expr.Coalesce(a, op(one, Operator.LT, one)), e("a ?? 1 < 1"));
 
 		// coalesce/term
 		assertEquals(new Expr.Coalesce(a, op(one, Operator.SUB, one)), e("a ?? 1 - 1"));
@@ -143,6 +143,33 @@ public class ParserTest extends TestBase {
 		assertEquals(op(one, Operator.POW, new Expr.Negate(one)), e("1 ^ -1"));
 		assertEquals(op(new Expr.Negate(one), Operator.POW, new Expr.Negate(one)), e("-1 ^ -1"));
 		assertEquals(op(new Expr.Negate(one), Operator.POW, one), e("-1 ^ 1"));
+
+		// ternary
+		assertEquals(
+				new Expr.Ternary(
+						op(a, Operator.GT, c(1)),
+						c(1),
+						c(0)
+				),
+				e("a > 1 ? 1 : 0")
+		);
+		assertEquals(
+				new Expr.Ternary(
+						op(a, Operator.GT, c(1)),
+						new Expr.Ternary(
+								op(a, Operator.LT, c(1)),
+								c(0),
+								c(1)
+						),
+						new Expr.Ternary(
+								op(a, Operator.LT, c(1)),
+								c(0),
+								c(1)
+						)
+				),
+				e("a > 1 ? a < 1 ? 0 : 1 : a < 1 ? 0 : 1")
+		);
+
 	}
 
 	@Test


### PR DESCRIPTION
This fixes the precedence for Ternaries, Conditionals, and Null Coalescence Operators being higher than expected according to Bedrock.dev, BlockBench's implementation of Molang, and testing the expressions in Bedrock.

[Bedrock.dev Operator Precedence](https://bedrock.dev/docs/stable/Molang#Operator%20Precedence)

## Snippet A
```c
return (a == b) ? c : d;
```
## Snippet B
```c
return a == b ? c : d;
```

These two Molang snippets should evaluate identically, and when tested in Blockbench and Bedrock they do.
However, when testing them in the current version of MolangKit, snippet B evaluates much differently than Snippet A.

Eg. `BinOp(a, '==', Ternary(b, c, d))` instead of `Ternary(BinOp(a, '==', b), c, d)`

This PR fixes this precedence issue, and evaluates both of these expressions identically.
