### PR TITLE
Revert arc functions mistakenly expecting degrees

### DIFF
--- a/src/main/java/com/eliotlash/molang/functions/classic/Acos.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Acos.java
@@ -7,9 +7,9 @@ import com.eliotlash.molang.variables.ExecutionContext;
 /**
  * Arc cosine function
  */
-public class AcosDegrees extends Function {
+public class Acos extends Function {
 
-    public AcosDegrees(String name) {
+    public Acos(String name) {
         super(name);
     }
 
@@ -20,7 +20,7 @@ public class AcosDegrees extends Function {
 
     @Override
     public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
-        double a = this.evaluateArgument(arguments, ctx, 0) / 180 * Math.PI;
+        double a = this.evaluateArgument(arguments, ctx, 0);
         if (Math.abs(a) > 1) {
             return 0;
         }

--- a/src/main/java/com/eliotlash/molang/functions/classic/Asin.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Asin.java
@@ -5,11 +5,11 @@ import com.eliotlash.molang.functions.Function;
 import com.eliotlash.molang.variables.ExecutionContext;
 
 /**
- * Arc tangent function
+ * Arc sine function
  */
-public class AtanDegrees extends Function {
+public class Asin extends Function {
 
-    public AtanDegrees(String name) {
+    public Asin(String name) {
         super(name);
     }
 
@@ -20,7 +20,10 @@ public class AtanDegrees extends Function {
 
     @Override
     public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
-        double a = this.evaluateArgument(arguments, ctx, 0) / 180 * Math.PI;
-        return Math.atan(a);
+        double a = this.evaluateArgument(arguments, ctx, 0);
+        if (Math.abs(a) > 1) {
+            return 0;
+        }
+        return Math.asin(a);
     }
 }

--- a/src/main/java/com/eliotlash/molang/functions/classic/Atan.java
+++ b/src/main/java/com/eliotlash/molang/functions/classic/Atan.java
@@ -5,11 +5,11 @@ import com.eliotlash.molang.functions.Function;
 import com.eliotlash.molang.variables.ExecutionContext;
 
 /**
- * Arc sine function
+ * Arc tangent function
  */
-public class AsinDegrees extends Function {
+public class Atan extends Function {
 
-    public AsinDegrees(String name) {
+    public Atan(String name) {
         super(name);
     }
 
@@ -20,10 +20,7 @@ public class AsinDegrees extends Function {
 
     @Override
     public double _evaluate(Expr[] arguments, ExecutionContext ctx) {
-        double a = this.evaluateArgument(arguments, ctx, 0) / 180 * Math.PI;
-        if (Math.abs(a) > 1) {
-            return 0;
-        }
-        return Math.asin(a);
+        double a = this.evaluateArgument(arguments, ctx, 0);
+        return Math.atan(a);
     }
 }

--- a/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
+++ b/src/main/java/com/eliotlash/molang/variables/ExecutionContext.java
@@ -133,9 +133,9 @@ public class ExecutionContext {
         addFunction(map, "math", new SinDegrees("sin"));
         addFunction(map, "math", new Sin("sinradians"));
         addFunction(map, "math", new Sign("sign"));
-        addFunction(map, "math", new AsinDegrees("asin"));
-        addFunction(map, "math", new AcosDegrees("acos"));
-        addFunction(map, "math", new AtanDegrees("atan"));
+        addFunction(map, "math", new Asin("asin"));
+        addFunction(map, "math", new Acos("acos"));
+        addFunction(map, "math", new Atan("atan"));
         addFunction(map, "math", new Atan2("atan2"));
         addFunction(map, "math", new Exp("exp"));
         addFunction(map, "math", new Ln("ln"));


### PR DESCRIPTION
Turns out the vanilla Molang arc functions actually do expect radians instead of degrees. Whoops...
This PR reverts the conversion from radians to degrees added in #8 