### PR TITLE
Update Maven CI authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: 'projects/824216268633/locations/global/workloadIdentityPools/github-actions/providers/github-actions-oidc'
-          service_account: 'github-actions@mw-lunarclient-maven-repo.iam.gserviceaccount.com'
+          service_account: 'github-actions-public-writer@mw-lunarclient-maven-repo.iam.gserviceaccount.com'
 
       - name: Use JDK 16
         uses: actions/setup-java@v1


### PR DESCRIPTION
Update the service-account selection in the existing Maven CI workflow. Build and publication commands remain unchanged.

Validation: the diff only changes the service-account email. Whitespace checks pass, and actionlint reports no new findings compared with the baseline.
